### PR TITLE
Flag a frame slot loaded again while a register still holds it

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ and only for flags -- the ABI guarantees they do not survive it.
     in-place sign/zero-extension is a single extending load: MOVZX EAX, byte
     [RSI]. Removes the load and its partial-register write; also MOVSX and the
     MOVSXD (32->64) form
+* redundant frame reload
+  - `488B442408 4889D1 488B5C2408` (MOV RAX, [RSP+8]; MOV RCX, RDX;
+    MOV RBX, [RSP+8]) -- the slot is loaded again while the first load's value
+    is still in a register: delete the reload when both name the same register,
+    or replace it with MOV RBX, RAX when they differ. Searched through
+    `APX_NDD_WINDOW`, past instructions that write neither the address
+    registers, nor the register holding the value, nor memory at all (any store
+    could be the slot, and proving otherwise is alias analysis). Restricted to
+    RSP/RBP bases on purpose: deleting a load is only safe where the memory
+    cannot be device memory, cannot race another thread, and cannot be a
+    relaxed atomic load that Go or Rust compiles to a plain MOV -- all true of
+    a frame slot and none guaranteed of a global or a pointer target, where
+    `gcc -O2` already performs this exact rewrite whenever it is legal, so what
+    survives is enriched for `volatile`. The residual risk is a volatile local
+    (the setjmp pattern), which no encoding distinguishes from a spill the
+    register allocator reloaded without noticing the value was still live
 * missing ANDN (only with `-m bmi1`)
   - `F7D0 21C8` (NOT EAX; AND EAX, ECX) -- one ANDN EAX, EAX, ECX (BMI1)
     computes ~x & y directly. An exact fold: both forms write only the

--- a/x86lint.c
+++ b/x86lint.c
@@ -3433,6 +3433,199 @@ static bool load_foldable_into_extend(const uint8_t *inst, size_t len,
            xed_get_largest_enclosing_register(dest);
 }
 
+// One frame slot's addressing, enough to decide that two loads name the same
+// bytes. Filled only for a load off RSP or RBP; `base` is INVALID otherwise.
+struct frame_slot {
+    xed_reg_enum_t base;        // enclosing RSP or RBP
+    xed_reg_enum_t index;       // enclosing, or INVALID
+    unsigned scale;
+    int64_t disp;
+    unsigned width;             // bytes accessed
+};
+
+// Describe `xedd` if it is a plain register load from the stack frame:
+// mov reg, [rsp/rbp + ...], no segment override, reading memory rather than
+// writing it. Returns the loaded register, or XED_REG_INVALID when the shape
+// does not match.
+//
+// Restricting the reload check to the frame is what makes it safe to delete a
+// memory access at all. A frame slot is private to one thread and is never
+// device memory, so the reads this drops cannot be an MMIO side effect, cannot
+// race another thread, and cannot be a relaxed atomic load that Go or Rust
+// compiles to a plain mov. The same cannot be said of a global or a
+// pointer dereference, where a second load of one address usually means the
+// compiler was forbidden to reuse the first -- CSE is otherwise universal, and
+// gcc -O2 already rewrites two reads of a plain global into one read and a
+// register copy, exactly this check's suggestion. What survives there is
+// enriched for volatile, so those forms are left alone.
+static xed_reg_enum_t frame_load_slot(const xed_decoded_inst_t *xedd,
+                                      struct frame_slot *slot)
+{
+    if (xed_decoded_inst_get_iclass(xedd) != XED_ICLASS_MOV ||
+        xed_decoded_inst_number_of_memory_operands(xedd) != 1 ||
+        !xed_decoded_inst_mem_read(xedd, 0) ||
+        xed_decoded_inst_mem_written(xedd, 0)) {
+        return XED_REG_INVALID;
+    }
+    xed_reg_enum_t seg = xed_decoded_inst_get_seg_reg(xedd, 0);
+    if (seg == XED_REG_FS || seg == XED_REG_GS) {
+        return XED_REG_INVALID;     // thread-local, not the frame
+    }
+    xed_reg_enum_t base = xed_decoded_inst_get_base_reg(xedd, 0);
+    if (xed_reg_class(base) != XED_REG_CLASS_GPR) {
+        return XED_REG_INVALID;
+    }
+    base = xed_get_largest_enclosing_register(base);
+    if (base != XED_REG_RSP && base != XED_REG_RBP) {
+        return XED_REG_INVALID;
+    }
+    xed_reg_enum_t dest = xed_decoded_inst_get_reg(xedd, XED_OPERAND_REG0);
+    if (xed_reg_class(dest) != XED_REG_CLASS_GPR) {
+        return XED_REG_INVALID;
+    }
+    xed_reg_enum_t index = xed_decoded_inst_get_index_reg(xedd, 0);
+    slot->base = base;
+    slot->index = xed_reg_class(index) == XED_REG_CLASS_GPR
+        ? xed_get_largest_enclosing_register(index) : XED_REG_INVALID;
+    slot->scale = xed_decoded_inst_get_scale(xedd, 0);
+    slot->disp = xed_decoded_inst_get_memory_displacement(xedd, 0);
+    slot->width = xed_decoded_inst_get_memory_operand_length(xedd, 0);
+    return dest;
+}
+
+// An instruction the reload check may look through. The address, the memory
+// it names, and the register holding the loaded value all have to survive it,
+// so it must not write the base or index (the address would move), must not
+// write the loaded register (the value would be gone), and must not write
+// memory at all -- a store anywhere could be the slot, and proving otherwise
+// is alias analysis this tool does not do. A LOCK prefix is a store by
+// another name. Control transfers end the straight-line path, and a call in
+// particular could write the frame through a pointer to it.
+//
+// Reads are all fine: memory reads change nothing, and reading the loaded
+// register is the point of loading it.
+static bool reload_gap_transparent(const xed_decoded_inst_t *gap,
+                                   const struct frame_slot *slot,
+                                   xed_reg_enum_t held)
+{
+    xed_category_enum_t category = xed_decoded_inst_get_category(gap);
+    if (category == XED_CATEGORY_CALL ||
+        category == XED_CATEGORY_RET ||
+        category == XED_CATEGORY_UNCOND_BR ||
+        category == XED_CATEGORY_COND_BR ||
+        category == XED_CATEGORY_SYSCALL ||
+        category == XED_CATEGORY_SYSRET ||
+        category == XED_CATEGORY_INTERRUPT) {
+        return false;
+    }
+    if (xed_operand_values_has_lock_prefix(
+            xed_decoded_inst_operands_const(gap))) {
+        return false;
+    }
+    unsigned nmem = xed_decoded_inst_number_of_memory_operands(gap);
+    for (unsigned m = 0; m < nmem; ++m) {
+        if (xed_decoded_inst_mem_written(gap, m)) {
+            return false;
+        }
+    }
+
+    const xed_inst_t *xi = xed_decoded_inst_inst(gap);
+    unsigned nops = xed_inst_noperands(xi);
+    for (unsigned i = 0; i < nops; ++i) {
+        const xed_operand_t *operand = xed_inst_operand(xi, i);
+        xed_operand_enum_t name = xed_operand_name(operand);
+        // The memory-addressing names carry the stack-pointer updates: push
+        // writes RSP through BASE0 and would move every RSP-relative slot.
+        if ((!xed_operand_is_register(name) &&
+             !xed_operand_is_memory_addressing_register(name)) ||
+            !xed_operand_written(operand)) {
+            continue;
+        }
+        xed_reg_enum_t enc = xed_get_largest_enclosing_register(
+            xed_decoded_inst_get_reg(gap, name));
+        if (enc == slot->base || enc == slot->index || enc == held) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Multi-instruction peephole. A frame slot loaded once and loaded again with
+// the first value still in a register is a load that need not happen: delete
+// it when the two loads name the same register, or replace it with
+// mov reload_dest, held when they differ -- either way one fewer memory read,
+// and fewer bytes than the [rsp + disp] form.
+//
+// `first` is the already-decoded load ending at `after_first`; on a match the
+// reload's decoding and offset come back through the out-parameters and the
+// caller reports against the reload, the instruction that goes away. The
+// search runs to APX_NDD_WINDOW, the bound the other windowed folds share,
+// through instructions that leave the address, the memory, and the held value
+// alone (reload_gap_transparent).
+//
+// Soundness rests on the frame restriction argued at frame_load_slot, plus
+// the usual window discipline: an incoming direct edge anywhere from the first
+// load's successor through the reload reaches the reload without having
+// executed the load whose register the rewrite reads, so the whole span
+// suppresses. The first load's destination must not be the base or index
+// either, or the address the reload computes is not the one that was loaded.
+//
+// The residual risk is a volatile local -- the setjmp pattern, where a
+// variable modified between setjmp and longjmp must be volatile and so is
+// reloaded deliberately. Nothing in the encoding distinguishes it from a
+// register allocator that spilled and reloaded without noticing the value was
+// still live, which is what the corpus is mostly made of.
+static bool frame_reload_redundant(const uint8_t *inst, size_t len,
+                                   const uint8_t *branch_targets,
+                                   size_t after_first,
+                                   const xed_decoded_inst_t *first,
+                                   xed_decoded_inst_t *reload_out,
+                                   size_t *reload_offset_out)
+{
+    struct frame_slot slot;
+    xed_reg_enum_t loaded = frame_load_slot(first, &slot);
+    if (loaded == XED_REG_INVALID) {
+        return false;
+    }
+    xed_reg_enum_t held = xed_get_largest_enclosing_register(loaded);
+    if (held == slot.base || held == slot.index) {
+        return false;   // the load moved the address it was loaded from
+    }
+
+    size_t cur = after_first;
+    for (int step = 0; step < APX_NDD_WINDOW - 1; ++step) {
+        if (cur >= len) {
+            return false;
+        }
+        decode_init(reload_out);
+        if (xed_decode(reload_out, inst + cur, len - cur) != XED_ERROR_NONE) {
+            return false;
+        }
+        size_t after = cur + xed_decoded_inst_get_length(reload_out);
+
+        struct frame_slot again;
+        xed_reg_enum_t redest = frame_load_slot(reload_out, &again);
+        if (redest == XED_REG_INVALID || again.base != slot.base ||
+            again.index != slot.index || again.scale != slot.scale ||
+            again.disp != slot.disp || again.width != slot.width) {
+            // Not the reload: look through it if it changes nothing the
+            // rewrite depends on.
+            if (!reload_gap_transparent(reload_out, &slot, held)) {
+                return false;
+            }
+            cur = after;
+            continue;
+        }
+
+        if (branch_target_in(branch_targets, after_first, after)) {
+            return false;
+        }
+        *reload_offset_out = cur;
+        return true;
+    }
+    return false;
+}
+
 // Window support for the copy folds below -- mov_add_foldable_to_lea and
 // the APX NDD fold share this proof and the APX_NDD_WINDOW bound: may the
 // scan look through `gap` -- is it provably independent of deleting the
@@ -5179,6 +5372,21 @@ int check_instructions(const uint8_t *inst, size_t len, bool verbose,
             summary_add(summary, "MOV constant foldable");
             report_finding("MOV constant foldable", offset, verbose, &xedd,
                 inst + offset);
+            ++errors;
+        }
+
+        // Multi-instruction peephole: a frame slot loaded again while the
+        // first load's value is still in a register. Reported against the
+        // reload, the instruction that goes away -- delete it outright when
+        // both loads name the same register, or replace it with a register
+        // copy when they differ. See frame_reload_redundant.
+        xed_decoded_inst_t frame_reload;
+        size_t frame_reload_offset;
+        if (frame_reload_redundant(inst, len, branch_targets, next, &xedd,
+                                   &frame_reload, &frame_reload_offset)) {
+            summary_add(summary, "redundant frame reload");
+            report_finding("redundant frame reload", frame_reload_offset,
+                verbose, &frame_reload, inst + frame_reload_offset);
             ++errors;
         }
 

--- a/x86lint_test.c
+++ b/x86lint_test.c
@@ -2850,6 +2850,140 @@ static void check_load_extend_fold_test(void)
     ASSERT_FINDINGS(reg_move, "load foldable into extend", 0);
 }
 
+// Multi-instruction peephole: a frame slot loaded twice while the first value
+// is still in a register. check_instructions reports it against the reload.
+// Deliberately restricted to RSP/RBP bases -- a thread-private, never-MMIO
+// slot -- since a second load of a global or a pointer target is usually one
+// the compiler was forbidden to fold.
+static void check_frame_reload_test(void)
+{
+    // mov rax, [rsp+8] ; mov rax, [rsp+8] -- the same slot into the same
+    // register with nothing in between: the second load is a pure duplicate.
+    static const uint8_t same_reg[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+    };
+    ASSERT_FINDINGS(same_reg, "redundant frame reload", 1);
+
+    // A different destination makes it a register copy rather than a deletion,
+    // which is still one fewer memory read.
+    static const uint8_t other_reg[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(other_reg, "redundant frame reload", 1);
+
+    // RBP-relative slots are the same frame.
+    static const uint8_t rbp_base[] = {
+        0x48, 0x8B, 0x45, 0xF8,        // mov rax, [rbp-8]
+        0x48, 0x8B, 0x5D, 0xF8,        // mov rbx, [rbp-8]
+    };
+    ASSERT_FINDINGS(rbp_base, "redundant frame reload", 1);
+
+    // A different displacement or a different access width is a different
+    // slot.
+    static const uint8_t other_disp[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x8B, 0x5C, 0x24, 0x10,  // mov rbx, [rsp+16]
+    };
+    ASSERT_FINDINGS(other_disp, "redundant frame reload", 0);
+    static const uint8_t other_width[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x8B, 0x5C, 0x24, 0x08,        // mov ebx, [rsp+8]
+    };
+    ASSERT_FINDINGS(other_width, "redundant frame reload", 0);
+
+    // A pointer dereference is not the frame: a compiler that left two loads
+    // of one address in place was usually not allowed to fold them, and
+    // nothing in the encoding says whether this is one of those.
+    static const uint8_t heap_base[] = {
+        0x48, 0x8B, 0x41, 0x08,        // mov rax, [rcx+8]
+        0x48, 0x8B, 0x59, 0x08,        // mov rbx, [rcx+8]
+    };
+    ASSERT_FINDINGS(heap_base, "redundant frame reload", 0);
+
+    // Nor is a global, even where both loads reach the same address: the two
+    // RIP displacements differ by the distance between the instructions.
+    static const uint8_t rip_base[] = {
+        0x48, 0x8B, 0x05, 0x07, 0x00, 0x00, 0x00,  // mov rax, [rip+7]
+        0x48, 0x8B, 0x1D, 0x00, 0x00, 0x00, 0x00,  // mov rbx, [rip+0]
+    };
+    ASSERT_FINDINGS(rip_base, "redundant frame reload", 0);
+
+    // The first load must not write the register the address is built from,
+    // or the reload names a different slot.
+    static const uint8_t load_moves_base[] = {
+        0x48, 0x8B, 0x64, 0x24, 0x08,  // mov rsp, [rsp+8]
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(load_moves_base, "redundant frame reload", 0);
+
+    // ---- The window, shared with the other multi-instruction folds.
+    const int one_gap = APX_NDD_WINDOW >= 3 ? 1 : 0;
+
+    static const uint8_t gap_fold[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x89, 0xD1,              // mov rcx, rdx
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(gap_fold, "redundant frame reload", one_gap);
+
+    // A gap may read the held value -- that is what it was loaded for.
+    static const uint8_t gap_reads_held[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x89, 0xC1,              // mov rcx, rax
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(gap_reads_held, "redundant frame reload", one_gap);
+
+    // Writing the held register loses the value the rewrite would copy.
+    static const uint8_t gap_writes_held[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x89, 0xD0,              // mov rax, rdx
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(gap_writes_held, "redundant frame reload", 0);
+
+    // Moving the stack pointer moves the slot.
+    static const uint8_t gap_writes_base[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x83, 0xEC, 0x10,        // sub rsp, 16
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(gap_writes_base, "redundant frame reload", 0);
+
+    // Any store could be the slot; proving otherwise is alias analysis.
+    static const uint8_t gap_stores[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0x48, 0x89, 0x11,              // mov [rcx], rdx
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(gap_stores, "redundant frame reload", 0);
+
+    // A call can write the frame through a pointer to it.
+    static const uint8_t gap_calls[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // mov rax, [rsp+8]
+        0xE8, 0x00, 0x00, 0x00, 0x00,  // call +0
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // mov rbx, [rsp+8]
+    };
+    ASSERT_FINDINGS(gap_calls, "redundant frame reload", 0);
+
+    // An incoming edge onto the reload reaches it without the load whose
+    // register the rewrite reads; one onto the head executes both.
+    static const uint8_t edge_on_reload[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // 0: mov rax, [rsp+8]
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // 5: mov rbx, [rsp+8]  <- target
+        0xEB, 0xF9,                    // 10: jmp 5
+    };
+    ASSERT_FINDINGS(edge_on_reload, "redundant frame reload", 0);
+    static const uint8_t edge_on_head[] = {
+        0x48, 0x8B, 0x44, 0x24, 0x08,  // 0: mov rax, [rsp+8]  <- target
+        0x48, 0x8B, 0x5C, 0x24, 0x08,  // 5: mov rbx, [rsp+8]
+        0xEB, 0xF4,                    // 10: jmp 0
+    };
+    ASSERT_FINDINGS(edge_on_head, "redundant frame reload", 1);
+}
+
 // Multi-instruction peephole: mov dest, srcA ; add dest, srcB is the
 // three-operand lea dest, [srcA + srcB]. check_instructions reports it against
 // the mov when the arithmetic flags the add would set are dead.
@@ -5207,6 +5341,7 @@ int main(int argc, char *argv[])
     check_lea_fold_test();
     check_mov_const_fold_test();
     check_load_extend_fold_test();
+    check_frame_reload_test();
     check_mov_add_lea_test();
     check_shift_pair_extend_test();
     check_cmp_one_branch_test();


### PR DESCRIPTION
A stack slot loaded twice, with the first load's value still standing in a
register, is a load that need not happen: delete the reload where both loads
name the same register, or replace it with a register copy where they differ.
One fewer memory read either way, and a byte or two shorter than the
`[rsp + disp]` form.

The search runs to `APX_NDD_WINDOW`, the bound the other windowed folds share,
through instructions that write neither the address registers, nor the register
holding the value, nor memory at all — any store could be the slot, and proving
otherwise is alias analysis this tool does not do. A `LOCK` prefix is a store by
another name, and a call can write the frame through a pointer to it.

## Why RSP/RBP only

This is the first check here to delete a memory access, and the restriction is
the whole soundness argument rather than a convenience. A frame slot is private
to one thread and is never device memory, so the read being dropped cannot be an
MMIO side effect, cannot race another thread, and cannot be a relaxed atomic
load — which Go and Rust both compile to a plain `MOV`.

None of that holds for a global or a pointer target, and for those the finding
is actively suspect, because the rewrite it suggests is one the compiler already
makes wherever it is allowed to:

```
int plain;  volatile sig_atomic_t vol;

plain_twice:  mov 0x0(%rip),%edi ; mov %edi,%esi          # gcc -O2 folds it
vol_twice:    mov 0x0(%rip),%edi ; mov 0x0(%rip),%esi     # required, left alone
```

`gcc -O2` folds the plain pair into exactly this check's suggestion and leaves
the volatile pair alone, so a surviving second load of a global is *enriched for
the case that must not be folded*. Those forms are excluded.

The residual risk that remains is a `volatile` local — the setjmp pattern, where
a variable modified between `setjmp` and `longjmp` must be volatile — which no
encoding distinguishes from a register allocator that spilled and reloaded
without noticing the value was still live. Documented in the check and the
README.

## Findings

| binary | this check | `tools/defuse`, same shape |
|---|---|---|
| bash | 6 | 27 |
| go | 0 | 1 |
| libcrypto | 11 | 33 |
| rustup | 146 | 665 |
| librustc_driver | 150 | 4932 |

The gap is deliberate: `defuse` keeps tracking across a conditional branch and
this does not, so every finding here is straight-line — where the README says
the analysis stays.

## Verification

Two sites reconcile in `objdump`:

```
# libcrypto, BN_mod_sqrt
4db0d:  mov -0x70(%rbp),%rsi
4db11:  mov %rbx,%rcx
4db14:  mov %r15,%rdx
4db17:  mov -0x70(%rbp),%rdi     <- rsi still holds it; mov %rsi,%rdi

# bash
bf340:  mov -0x60(%rbp),%r15
bf344:  mov -0x60(%rbp),%rsi     <- mov %r15,%rsi
```

15 new tests, green at `APX_NDD_WINDOW` 2/3/8/16. Negatives pin every exclusion:
heap base, RIP base (with both loads genuinely reaching one address), store in
the gap, call in the gap, base moved, held register overwritten, edge on the
reload. `make check` passes; no new compiler warnings.

Scan time on go moves 2.83s → 3.20s, more than the other windowed checks cost,
since the walk runs for every frame load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
